### PR TITLE
Highlight resource parameters as functions

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -443,7 +443,13 @@ of the initial include plus puppet-include-indent."
     (,(rx (group (eval (list 'regexp puppet-builtin-metaparameters-re)))
           (zero-or-more space)
           "=>") 1 font-lock-builtin-face)
-     ;; Built-in functions
+    ;; Standard meta parameters
+    (,(rx symbol-start
+          (group (one-or-more (any "A-Z" "a-z" "0-9" "_")))
+          symbol-end
+          (zero-or-more space)
+          "=>") 1 font-lock-function-name-face)
+    ;; Built-in functions
     (,(rx (group (eval (list 'regexp puppet-builtin-functions-re))))
      1 font-lock-builtin-face))
   "Font lock keywords for Puppet Mode.")


### PR DESCRIPTION
Now:
![standard](https://f.cloud.github.com/assets/224922/2384600/b11a8d18-a90f-11e3-898f-a648605aaa37.png)

With this PR:
![highlighted](https://f.cloud.github.com/assets/224922/2384601/b5eeba9e-a90f-11e3-973a-7a92db902bf6.png)

@bbatsov What do you think?
