### PR TITLE
Power up docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,10 @@ Features
 1. Syntax highlighting
 2. Indentation and alignment of expressions and statements
 3. Tag navigation (aka `imenu`)
-4. Validation and linting of manifests
+4. Manual validation and linting of manifests (see Flycheck_ for on-the-fly
+   validation and linting)
+
+.. _Flycheck: http://flycheck.readthedocs.org/en/latest/
 
 Installation
 ============

--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -71,6 +71,10 @@
 ;; with `puppet-lint' on C-c C-l.  Apply the current buffer with `puppet-apply'
 ;; on C-c C-c.
 
+;; Flymake: Flymake support is _not_ provided. See Flycheck at
+;; http://flycheck.readthedocs.org/en/latest/ for on-the-fly validation and
+;; liniting of Puppet manifests.
+
 ;;;;
 
 ;;; Code:


### PR DESCRIPTION
Improves the intro in the README.  Now tells the user which version of Puppet and Emacs we support, and [what Puppet actually is (for folks who can't google)](http://www.reddit.com/r/emacs/comments/20bnj3/puppet_mode_03_release_new_commands_and_major/cg23b9w).  I've also added all features to the commentary of the mode.

Last, but not least, I've referenced Flycheck in the docs for on-the-fly linting.  I think it's a useful addition to Puppet Mode, but I'm unsure whether that's ok.  After all, it's my own project, too, so it smells like nasty advertising, doesn't it?  I'd like to hear your opinion, @bbatsov 
