### PR TITLE
Add pcase fix for emacs 24.1

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -218,8 +218,8 @@ Return nil, if there is no special context at POS, or one of
     (if (nth 4 state)
         'comment
       (pcase (nth 3 state)
-        (?\' 'single-quoted)
-        (?\" 'double-quoted)))))
+        (`?\' 'single-quoted)
+        (`?\" 'double-quoted)))))
 
 (defun puppet-in-string-or-comment-p (&optional pos)
   "Determine whether POS is inside a string or comment."


### PR DESCRIPTION
Support for self-quoting Qpatterns wasn't added until 24.2. Explicit quoting was necessary before then.

This fixes a variety of behavior and font-lock issues under 24.1 that manifest as the message "Unknown upattern 39"
