### PR TITLE
Closes #52 - Set require-final-line to the value of mode-require-final-line, not t

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -1082,7 +1082,7 @@ for each entry."
 
 \\{puppet-mode-map}"
   ;; Misc variables
-  (setq-local require-final-newline t)
+  (setq-local require-final-newline mode-require-final-newline)
   ;; Comment setup
   (setq-local comment-start "# ")
   (setq-local comment-start-skip "#+ *")


### PR DESCRIPTION
Note: I've been calling it `require-final-line` and `mode-require-final-line`, which is wrong. The actual names are `require-final-newline` and `mode-require-final-newline`, which is what I've actually done here.
