### PR TITLE
Uniform region alignment

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -867,7 +867,8 @@ Used as `syntax-propertize-function' in Puppet Mode."
   '((puppet-resource-arrow
      (regexp . "\\(\\s-*\\)=>\\(\\s-*\\)")
      (group  . (1 2))
-     (modes  . '(puppet-mode))))
+     (modes  . '(puppet-mode))
+     (separate . entire)))
   "Align rules for Puppet Mode.")
 
 (defun puppet-align-block ()


### PR DESCRIPTION
In cases where the variables are separated for readability, align the
entire region.  For example a class that looks like:

```
 class { 'graphite::web::config':
   secret_key => $secret_key,

   database_name     => $database_name,
   database_username => $database_username,
   database_password => $database_password,
   database_host     => $database_host,
   database_port     => $database_port,
 }

Will be aligned like:

 class { 'graphite::web::config':
   secret_key            => $secret_key,

   database_name         => $database_name,
   database_username     => $database_username,
   database_password     => $database_password,
   database_host         => $database_host,
   database_port         => $database_port,
 }
```
