### PR TITLE
Tests and fixes for issue #60 indentation of function arguments

### DIFF
--- a/puppet-mode.el
+++ b/puppet-mode.el
@@ -588,6 +588,19 @@ of the initial include plus puppet-include-indent."
         ;; comma and we're at the inner block, so we should indent it matching
         ;; the indentation of the opening brace of the block.
         (setq cur-indent block-indent))
+
+       ;; Class argument list ends with a closing paren and needs to be
+       ;; indented to the level of the class token.
+       ((looking-at "^\s+\).*?{\s*$")
+        ;; Find the indentation level of the opening line.
+        (let ((prev-class-indentation nil))
+          (save-excursion
+            (while (not prev-class-indentation)
+              (forward-line -1)
+              (when (looking-at "\s?class\s+.*?\($")
+                (setq prev-class-indentation (current-indentation)))))
+          (setq cur-indent prev-class-indentation))
+        (setq not-indented nil))
        (t
         ;; Otherwise, we did not start on a block-ending-only line.
         (save-excursion
@@ -603,7 +616,7 @@ of the initial include plus puppet-include-indent."
 
              ;; Brace or paren on a line by itself will already be indented to
              ;; the right level, so we can cheat and stop there.
-             ((looking-at "^\\s-*[\)}]\\s-*")
+             ((looking-at "^\\s-*[\)}]\\s-*\s?$")
               (setq cur-indent (current-indentation))
               (setq not-indented nil))
 

--- a/test/puppet-mode-test.el
+++ b/test/puppet-mode-test.el
@@ -563,6 +563,91 @@ package { 'bar':
                      ("package 'foo'" . 93))))))
 
 
+;;;; Indentation
+
+(ert-deftest puppet-indent-line/class ()
+  (puppet-test-with-temp-buffer
+      "class test (
+$foo = $title,
+  ) {
+$bar = 'hello'
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "class test (
+  $foo = $title,
+) {
+  $bar = 'hello'
+}"
+))))
+
+(ert-deftest puppet-indent-line/class-inherits ()
+  (puppet-test-with-temp-buffer
+      "class test (
+$foo = $title,
+  ) inherits ::something::someting:dark::side {
+$bar = 'hello'
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "class test (
+  $foo = $title,
+) inherits ::something::someting:dark::side {
+  $bar = 'hello'
+}"
+))))
+
+(ert-deftest puppet-indent-line/class-no-parameters ()
+  (puppet-test-with-temp-buffer
+      "class test () {
+$bar = 'hello'
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "class test () {
+  $bar = 'hello'
+}"
+))))
+
+(ert-deftest puppet-indent-line/class-no-parameters-2 ()
+  (puppet-test-with-temp-buffer
+      "class foobar {
+class { 'test':
+omg => 'omg',
+lol => {
+asd => 'asd',
+fgh => 'fgh',
+}
+}
+}
+"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "class foobar {
+  class { 'test':
+    omg => 'omg',
+    lol => {
+      asd => 'asd',
+      fgh => 'fgh',
+    }
+  }
+}
+"
+))))
+
+(ert-deftest puppet-indent-line/class-no-parameters-inherits ()
+  (puppet-test-with-temp-buffer
+      "class test () inherits ::something::someting:dark::side {
+$bar = 'hello'
+}"
+    (indent-region (point-min) (point-max))
+    (should (string= (buffer-string)
+                     "class test () inherits ::something::someting:dark::side {
+  $bar = 'hello'
+}"
+))))
+
+
 ;;;; Major mode definition
 
 (ert-deftest puppet-mode/movement-setup ()


### PR DESCRIPTION
Fixes https://github.com/lunaryorn/puppet-mode/issues/60.

Due to the way the tests are implemented, a bit of output will be interspersed with the checks, e.g.:

```
   passed  41/63  puppet-imenu-create-index/define-with-argument
   passed  42/63  puppet-imenu-create-index/node-with-resources
Indenting region...
Indenting region...done
   passed  43/63  puppet-indent-line/class
Indenting region...
Indenting region...done
   passed  44/63  puppet-indent-line/class-inherits
Indenting region...
Indenting region...done
   passed  45/63  puppet-indent-line/class-no-parameters
Indenting region...
Indenting region...done
   passed  46/63  puppet-indent-line/class-no-parameters-2
Indenting region...
Indenting region...done
   passed  47/63  puppet-indent-line/class-no-parameters-inherits
   passed  48/63  puppet-mode-syntax-table/fontify-c-style-comment
```

If you have any idea how I can avoid that, I'm all ears...